### PR TITLE
fix: prevent letter index reset after incorrect guess

### DIFF
--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -86,7 +86,6 @@ const Main = () => {
             ...tempGuessArray[guessRef.current],
             shakeIt:true
           };
-          letterRef.current = 0;
           return tempGuessArray;
         }else {
           const tempGuessArrayWithResult = compareWords(guessRef.current, tempGuessArray);


### PR DESCRIPTION
## What this PR does
- Prevents letter index from resetting after an incorrect guess

## Why
- Fixes bug where index reset to 0 but previous letters stayed, causing new input to overwrite old letters